### PR TITLE
Conda Env from HDFS

### DIFF
--- a/rambling_jvm/src/main/scala/com/continuumio/rambling/ApplicationMaster.scala
+++ b/rambling_jvm/src/main/scala/com/continuumio/rambling/ApplicationMaster.scala
@@ -1,6 +1,7 @@
 package com.continuumio.rambling
 
 import java.util.Collections
+import java.net._
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.yarn.api.ApplicationConstants
@@ -69,7 +70,9 @@ object ApplicationMaster {
 
       //setup local resources
       val appMasterPython = Records.newRecord(classOf[LocalResource])
-      setUpLocalResource(new Path("hdfs://localhost:9000/jars/miniconda-env.zip"),appMasterPython, archived = true)
+      val uri = new URI(jarPath)
+      val hdfsURI = jarPath.replace(uri.getPath, "")
+      setUpLocalResource(new Path(hdfsURI + "/jars/miniconda-env.zip"),appMasterPython, archived = true)
 
       //set up local ENV
       val env = collection.mutable.Map[String,String]()

--- a/rambling_jvm/src/main/scala/com/continuumio/rambling/Utils.scala
+++ b/rambling_jvm/src/main/scala/com/continuumio/rambling/Utils.scala
@@ -14,12 +14,15 @@ import scala.collection.JavaConverters._
 object Utils {
 
   // add details of the local resource*
-  def setUpLocalResource(resourcePath: Path, resource: LocalResource)(implicit conf:Configuration) = {
+  def setUpLocalResource(resourcePath: Path, resource: LocalResource, archived: Boolean = false)(implicit conf:Configuration) = {
+
+    val fileType = if (archived) LocalResourceType.ARCHIVE else LocalResourceType.FILE
+
     val jarStat = FileSystem.get(conf).getFileStatus(resourcePath)
     resource.setResource(ConverterUtils.getYarnUrlFromPath(resourcePath))
     resource.setSize(jarStat.getLen())
     resource.setTimestamp(jarStat.getModificationTime())
-    resource.setType(LocalResourceType.FILE)
+    resource.setType(fileType)
     resource.setVisibility(LocalResourceVisibility.PUBLIC)
   }
 


### PR DESCRIPTION
Uses Conda environment from HDFS if `/jars/miniconda-env.zip` exists on HDFS and users uses `$PYTHON_BIN`.  For example,

```
cmd = "$PYTHON_BIN $CONDA_PREFIX/bin/dworker 172.31.0.230:9999"
```
