### PR TITLE
CLI Arg Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ r.get_application_logs(appId)
 
 ### JAVA
 ```
-hadoop jar ./rambling-1.0-SNAPSHOT.jar com.continuumio.rambling.Client hdfs://{{NAMENODE}}:9000/jars/rambling-1.0-SNAPSHOT.jar 1 "python -c 'import sys; print(sys.path); import random; print(str(random.random()))' 1 128"
+hadoop jar ./rambling-1.0-SNAPSHOT.jar com.continuumio.rambling.Client --jarPath hdfs://{{NAMENODE}}:9000/jars/rambling-1.0-SNAPSHOT.jar --numInstances 1 --command "python -c 'import sys; print(sys.path); import random; print(str(random.random()))'"
 ```
+hadoop jar ./target/rambling-1.0-SNAPSHOT.jar com.continuumio.rambling.Client --jarPath hdfs://localhost:9000/jars/rambling-1.0-SNAPSHOT.jar --numInstances 1 --command "python -c 'import sys; print(sys.path); import random; print(str(random.random()))'"
 
 Originally forked from: https://github.com/phatak-dev/blog/tree/master/code/YarnScalaHelloWorld
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ r.get_application_logs(appId)
 
 ### JAVA
 ```
+hadoop jar ./rambling-1.0-SNAPSHOT.jar com.continuumio.rambling.Client --help
 hadoop jar ./rambling-1.0-SNAPSHOT.jar com.continuumio.rambling.Client --jarPath hdfs://{{NAMENODE}}:9000/jars/rambling-1.0-SNAPSHOT.jar --numInstances 1 --command "python -c 'import sys; print(sys.path); import random; print(str(random.random()))'"
 ```
-hadoop jar ./target/rambling-1.0-SNAPSHOT.jar com.continuumio.rambling.Client --jarPath hdfs://localhost:9000/jars/rambling-1.0-SNAPSHOT.jar --numInstances 1 --command "python -c 'import sys; print(sys.path); import random; print(str(random.random()))'"
 
 Originally forked from: https://github.com/phatak-dev/blog/tree/master/code/YarnScalaHelloWorld
 

--- a/rambling/core.py
+++ b/rambling/core.py
@@ -71,8 +71,9 @@ class Rambling(object):
         """
 
         JAR_FILE_PATH = os.path.join(os.path.dirname(__file__), "java_libs", JAR_FILE)
-        args = ["hadoop", "jar", JAR_FILE_PATH, JAVA_APP, self.HDFS_JAR_PATH,
-                str(num_containers), cmd, str(virtual_cores), str(memory)]
+        args = ["hadoop", "jar", JAR_FILE_PATH, JAVA_APP, "--jarPath", self.HDFS_JAR_PATH,
+                "--numInstances", str(num_containers), "--command", cmd, "--virutalCores",
+                str(virtual_cores), "--memory", str(memory)]
 
         logger.debug("Running Command: {}".format(' '.join(args)))
         proc = Popen(args, stdout=PIPE, stderr=PIPE)

--- a/rambling_jvm/pom.xml
+++ b/rambling_jvm/pom.xml
@@ -7,6 +7,10 @@
             <id>cloudera</id>
             <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
         </repository>
+        <repository>
+            <id>mvnrepository</id>
+            <url>http://mvnrepository.com/</url>
+        </repository>
     </repositories>
     <modelVersion>4.0.0</modelVersion>
 
@@ -44,6 +48,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.scopt</groupId>
+            <artifactId>scopt_2.11</artifactId>
+            <version>3.3.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/rambling_jvm/src/main/scala/com/continuumio/rambling/Client.scala
+++ b/rambling_jvm/src/main/scala/com/continuumio/rambling/Client.scala
@@ -1,9 +1,14 @@
 package com.continuumio.rambling
 
-import java.util.Collections
-import java.net._
-
 import com.continuumio.rambling.Utils._
+import com.continuumio.rambling.ClientArguments.parseArgs
+
+import java.net._
+import java.util.Collections
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.{ArrayBuffer, HashMap}
+
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileSystem
@@ -15,8 +20,6 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.Records
 import org.apache.log4j.Logger
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 /**
  * Entry point into the Yarn application.
@@ -27,15 +30,17 @@ import scala.collection.mutable.{ArrayBuffer, HashMap}
 object Client extends Logging {
 
   def main(args: Array[String]) {
+    val parsedArgs = parseArgs(args)
+    println(parsedArgs)
 
     logger.info("Staring Application Master")
 
     implicit val conf = new YarnConfiguration()
-    val jarPath = args(0)
-    val numberOfInstances = args(1).toInt
-    val CMD = args(2)
-    val vCores = args(3).toInt
-    val mem = args(4).toInt
+    val jarPath = parsedArgs.jarPath
+    val numberOfInstances = parsedArgs.numInstances
+    val CMD = parsedArgs.command
+    val vCores = parsedArgs.virutalCores
+    val mem = parsedArgs.memory
 
     val cleanedCMD = CMD.replace("\"", "\'")
     val shellCMD = "\\\""+cleanedCMD+"\\\""

--- a/rambling_jvm/src/main/scala/com/continuumio/rambling/ClientArgParse.scala
+++ b/rambling_jvm/src/main/scala/com/continuumio/rambling/ClientArgParse.scala
@@ -1,0 +1,51 @@
+package com.continuumio.rambling
+
+import java.io.File
+import scopt._
+
+case class Config(numInstances: Int = 1, memory: Int = 300, virutalCores: Int = 1,
+                  command: String = "", jarPath: String = "", debug: Boolean = false)
+
+object ClientArguments {
+  val parser = new scopt.OptionParser[Config]("scopt") {
+    head("rambling", "x.1")
+    opt[Int]('n', "numInstances") action { (x, c) =>
+      c.copy(numInstances = x)
+    } text ("Number of YARN containers")
+
+    opt[Int]('m', "memory") action { (x, c) =>
+      c.copy(memory = x)
+    } text ("Amount of memory per container")
+
+    opt[Int]('c', "virutalCores") action { (x, c) =>
+      c.copy(virutalCores = x)
+    } text ("Virtual cores per container")
+
+    opt[String]('C', "command") action { (x, c) =>
+      c.copy(command = x)
+    } text ("Command to run in containers")
+
+    opt[String]('j', "jarPath") action { (x, c) =>
+      c.copy(jarPath = x)
+    } text ("Number of YARN containers ")
+
+    opt[Unit]("debug") hidden() action { (_, c) =>
+      c.copy(debug = true)
+    } text ("this option is hidden in the usage text")
+
+    help("help") text ("command line for launching distributed python")
+
+  }
+
+  def parseArgs(args: Array[String]) : Config = {
+    val parsed = parser.parse(args, Config())
+    var parsedArgs = Config()
+    parsed match {
+      case Some(config) =>
+        parsedArgs = config
+      case None =>
+        //raise
+    }
+    parsedArgs
+  }
+}


### PR DESCRIPTION
Switching from arg ordered parsing:

``` scala
a = args(0)
b = args(1)
```

to [scopt](https://github.com/scopt/scopt)

``` scala
opt[Int]('n', "numInstances") action { (x, c) =>
      c.copy(numInstances = x)
    } text ("Number of YARN containers")
....
```

This leads to a much more robust spelling on the CLI and backend processing:

```
hadoop jar ./rambling-1.0-SNAPSHOT.jar com.continuumio.rambling.Client --jarPath hdfs://{{NAMENODE}}:9000/jars/rambling-1.0-SNAPSHOT.jar --numInstances 1 --command "date'"
```
