### PR TITLE
Zipped Python Envs

### DIFF
--- a/knit/core.py
+++ b/knit/core.py
@@ -78,7 +78,7 @@ class Knit(object):
             A yarn application ID string
         """
 
-        args = ["hadoop", "jar", self.JAR_FILE_PATH, JAVA_APP, "--numInstances", str(num_containers),
+        args = ["hadoop", "jar", self.JAR_FILE_PATH, JAVA_APP, "--numContainers", str(num_containers),
                 "--command", cmd, "--virutalCores", str(virtual_cores), "--memory", str(memory)]
 
         logger.debug("Running Command: {}".format(' '.join(args)))

--- a/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
@@ -1,4 +1,6 @@
 package io.continuum.knit
+
+import java.io.File
 import java.util.Collections
 import java.net._
 
@@ -10,7 +12,10 @@ import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest
 import org.apache.hadoop.yarn.client.api.{AMRMClient, NMClient}
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.util.Records
-import Utils._
+
+import io.continuum.knit.Utils._
+import io.continuum.knit.ApplicationMasterArguments.{parseArgs}
+
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
@@ -19,10 +24,16 @@ object ApplicationMaster {
 
 
   def main(args: Array[String]) {
-    val n = args(0).toInt
-    val shellCMD = args(1)
-    val vCores = args(2).toInt
-    val mem = args(3).toInt
+    val parsedArgs = parseArgs(args)
+    println(parsedArgs)
+
+    val pythonEnv = parsedArgs.pythonEnv
+    val numberOfInstances = parsedArgs.numInstances
+    val CMD = parsedArgs.command
+    val vCores = parsedArgs.virutalCores
+    val mem = parsedArgs.memory
+
+
 
     println("Running command in container: " + shellCMD)
     val cmd = List(
@@ -116,5 +127,7 @@ object ApplicationMaster {
     rmClient.unregisterApplicationMaster(
       FinalApplicationStatus.SUCCEEDED, "", "")
   }
+
+
 
 }

--- a/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
@@ -28,10 +28,11 @@ object ApplicationMaster {
     println(parsedArgs)
 
     val pythonEnv = parsedArgs.pythonEnv
-    val numberOfInstances = parsedArgs.numInstances
-    val CMD = parsedArgs.command
-    val vCores = parsedArgs.virutalCores
+    val numContainers = parsedArgs.numContainers
+    val shellCMD = parsedArgs.command
+    val vCores = parsedArgs.virtualCores
     val mem = parsedArgs.memory
+
 
 
 
@@ -69,7 +70,7 @@ object ApplicationMaster {
 
 
     //request for containers
-    for ( i <- 1 to n) {
+    for ( i <- 1 to numContainers) {
       val containerAsk = new ContainerRequest(resource,null,null,priority)
       println("asking for " +s"$i")
       rmClient.addContainerRequest(containerAsk)
@@ -78,7 +79,7 @@ object ApplicationMaster {
     var responseId = 0
     var completedContainers = 0
 
-    while( completedContainers < n) {
+    while( completedContainers < numContainers) {
 
       //setup local resources
 //      val appMasterPython = Records.newRecord(classOf[LocalResource])

--- a/knit_jvm/src/main/scala/io/continuum/knit/Client.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/Client.scala
@@ -41,15 +41,18 @@ object Client extends Logging {
     setDependencies()
 
     val pythonEnv = parsedArgs.pythonEnv
-    val numberOfInstances = parsedArgs.numInstances
+    val numberOfInstances = parsedArgs.numContainers
     val CMD = parsedArgs.command
-    val vCores = parsedArgs.virutalCores
+    val vCores = parsedArgs.virtualCores
     val mem = parsedArgs.memory
 
     val cleanedCMD = CMD.replace("\"", "\'")
     val shellCMD = "\\\""+cleanedCMD+"\\\""
 
+    val cleanedParsed = parsedArgs.copy(command = shellCMD)
+
     logger.info("Running commmand: " + shellCMD)
+
     val stagingDir = ".knitDeps"
     val stagingDirPath = new Path(fs.getHomeDirectory(), stagingDir)
     val KNIT_JAR = new Path(stagingDirPath, "knit-1.0-SNAPSHOT.jar")
@@ -93,9 +96,9 @@ object Client extends Logging {
     setUpEnv(env)
     amContainer.setEnvironment(env.asJava)
 
-    val cmdStr = ApplicationMasterCMD(parsedArgs)
+    val cmdStr = ApplicationMasterCMD(cleanedParsed)
     println(s"$cmdStr")
-    sys.exit(1)
+
     //application master is a just java program with given commands
     amContainer.setCommands(List(
       "$JAVA_HOME/bin/java" +

--- a/knit_jvm/src/main/scala/io/continuum/knit/Client.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/Client.scala
@@ -46,6 +46,8 @@ object Client extends Logging {
     val vCores = parsedArgs.virtualCores
     val mem = parsedArgs.memory
 
+    //TODO: Better processing of $ in CLI args
+    //Expected only to be used with `python_env`
     val cleanedCMD = CMD.replace("\"", "\'")
     val shellCMD = "\\\""+cleanedCMD+"\\\""
 
@@ -74,14 +76,15 @@ object Client extends Logging {
 
 
 
-    //TODO: move to .knitDeps and allow for users to define zip name and file location
-//    val appMasterPython = Records.newRecord(classOf[LocalResource])
-//    val PYTHON_ZIP = new Path("/jars/miniconda-env.zip").makeQualified(fs.getUri, fs.getWorkingDirectory)
-//    setUpLocalResource(PYTHON_ZIP,appMasterPython, archived = true)
-
     val localResources = HashMap[String, LocalResource]()
-//    localResources("PYTHON_DIR") = appMasterPython
-//    localResources("PYTHON_DIR3") = appMasterPython
+    if (!pythonEnv.isEmpty) {
+      //TODO: detect file suffix
+      uploadFile(pythonEnv)
+      val appMasterPython = Records.newRecord(classOf[LocalResource])
+      val PYTHON_ZIP = new Path(stagingDirPath, "miniconda-env.zip").makeQualified(fs.getUri, fs.getWorkingDirectory)
+      setUpLocalResource(PYTHON_ZIP, appMasterPython, archived = true)
+      localResources("PYTHON_DIR") = appMasterPython
+    }
 
     //add the jar which contains the Application master code to classpath
     localResources("knit.jar") = appMasterJar

--- a/knit_jvm/src/main/scala/io/continuum/knit/Client.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/Client.scala
@@ -2,7 +2,7 @@ package io.continuum.knit
 import java.io.File
 
 import io.continuum.knit.Utils._
-import io.continuum.knit.ClientArguments.parseArgs
+import io.continuum.knit.ClientArguments.{parseArgs, ApplicationMasterCMD}
 
 import java.net._
 import java.util.Collections
@@ -40,7 +40,7 @@ object Client extends Logging {
     val fs = FileSystem.get(conf)
     setDependencies()
 
-//    val jarPath = parsedArgs.jarPath
+    val pythonEnv = parsedArgs.pythonEnv
     val numberOfInstances = parsedArgs.numInstances
     val CMD = parsedArgs.command
     val vCores = parsedArgs.virutalCores
@@ -93,12 +93,15 @@ object Client extends Logging {
     setUpEnv(env)
     amContainer.setEnvironment(env.asJava)
 
+    val cmdStr = ApplicationMasterCMD(parsedArgs)
+    println(s"$cmdStr")
+    sys.exit(1)
     //application master is a just java program with given commands
     amContainer.setCommands(List(
       "$JAVA_HOME/bin/java" +
         " -Xmx256M" +
         " io.continuum.knit.ApplicationMaster" +
-        "  " + numberOfInstances + "  " + shellCMD + " " + vCores + " " + mem + " " +
+        "  " + cmdStr + " " +
         " 1>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stdout" +
         " 2>" + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/stderr"
     ).asJava)
@@ -123,5 +126,4 @@ object Client extends Logging {
     client.submitApplication(appContext)
 
   }
-
 }

--- a/knit_jvm/src/main/scala/io/continuum/knit/ClientArgParse.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/ClientArgParse.scala
@@ -2,14 +2,14 @@ package io.continuum.knit
 import java.io.File
 import scopt._
 
-case class Config(numInstances: Int = 1, memory: Int = 300, virutalCores: Int = 1,
+case class ClientConfig(numContainers: Int = 1, memory: Int = 300, virtualCores: Int = 1,
                   command: String = "", pythonEnv: String = "", debug: Boolean = false)
 
 object ClientArguments {
-  val parser = new scopt.OptionParser[Config]("scopt") {
+  val parser = new scopt.OptionParser[ClientConfig]("scopt") {
     head("knit", "x.1")
-    opt[Int]('n', "numInstances") action { (x, c) =>
-      c.copy(numInstances = x)
+    opt[Int]('n', "numContainers") action { (x, c) =>
+      c.copy(numContainers = x)
     } text ("Number of YARN containers")
 
     opt[Int]('m', "memory") action { (x, c) =>
@@ -17,7 +17,7 @@ object ClientArguments {
     } text ("Amount of memory per container")
 
     opt[Int]('c', "virtualCores") action { (x, c) =>
-      c.copy(virutalCores = x)
+      c.copy(virtualCores = x)
     } text ("Virtual cores per container")
 
     opt[String]('C', "command") action { (x, c) =>
@@ -36,13 +36,13 @@ object ClientArguments {
 
   }
 
-  def parseArgs(args: Array[String]) : Config = {
-    val parsed = parser.parse(args, Config())
+  def parseArgs(args: Array[String]) : ClientConfig = {
+    val parsed = parser.parse(args, ClientConfig())
     val parsedArgs = parsed.getOrElse( sys.exit(1) )
     parsedArgs
   }
 
-  def ApplicationMasterCMD(config: Config): String = {
+  def ApplicationMasterCMD(config: ClientConfig): String = {
 
     var cmdSeq = Seq.empty[String]
 

--- a/knit_jvm/src/main/scala/io/continuum/knit/Utils.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/Utils.scala
@@ -63,6 +63,22 @@ object Utils {
     }
   }
 
+  def uploadFile(filePath: String)(implicit conf: YarnConfiguration) = {
+    val fs = FileSystem.get(conf)
+    val stagingDir = ".knitDeps"
+    val stagingDirPath = new Path(fs.getHomeDirectory(), stagingDir)
+
+    val FILE_PATH = new File(filePath).getAbsolutePath()
+    println(s"Attemping upload of $FILE_PATH")
+
+    // upload all files to stagingDir
+    List(FILE_PATH).foreach {
+      case (file) =>
+        val p = getQualifiedLocalPath(Utils.resolveURI(file))
+        copyFileToRemote(stagingDirPath, p, 1)
+    }
+  }
+
   def copyFileToRemote(destDir: Path, srcPath: Path,
                        replication: Short)(implicit conf: Configuration): Unit = {
 


### PR DESCRIPTION
PR let's users upload zipped python directory (requires python binary) as part of job submission:

``` python
k = knit.Knit()
cmd = '$PYTHON_BIN -c "import sys; print(sys.path); import random; print(str(random.random()))"'
python_env = "<FULL-PATH>/miniconda-env.zip"
appId = k.start_application(cmd, python_env=python_env)
```

Note: Because Scala uses double quotes (") for strings and single quotes (') for chars the `CMD` with ENV variable must be spelled out in a specific way with ENV vars inside single quotes
