### PR TITLE
Python 2.6 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 python:
+  - 2.6
   - 2.7
   - 3.5
 
@@ -18,11 +19,15 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - pwd
-  - echo $PYTHON_VERSION
+  - echo $TRAVIS_PYTHON_VERSION
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       export DOCKER_ENV=/opt/anaconda;
     else
-      export DOCKER_ENV=/opt/anaconda/envs/py3;
+      if [[ "$TRAVIS_PYTHON_VERSION" == "2.6" ]]; then
+        export DOCKER_ENV=/opt/anaconda/envs/py26;
+      else
+        export DOCKER_ENV=/opt/anaconda/envs/py3;
+      fi
     fi
   - pushd continuous_integration
   - docker-compose up -d
@@ -36,7 +41,8 @@ install:
 
 script:
   - pwd
-  - docker exec -it $CONTAINER_ID bash /knit/continuous_integration/coverage_test.sh
+  - echo $DOCKER_ENV
+  - docker exec -it $CONTAINER_ID bash /knit/continuous_integration/coverage_test.sh $DOCKER_ENV
 
 after_success:
   - docker exec -it $CONTAINER_ID bash -c "export TRAVIS=$TRAVIS && export TRAVIS_JOB_ID=$TRAVIS_JOB_ID && TRAVIS_BRANCH=$TRAVIS_BRANCH && /knit/continuous_integration/coverage_upload.sh"

--- a/continuous_integration/Dockerfile
+++ b/continuous_integration/Dockerfile
@@ -7,8 +7,10 @@ RUN /bin/bash /tmp/miniconda.sh -b -p /opt/anaconda
 RUN rm /tmp/miniconda.sh
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -y -q pip coverage pytest requests apache-maven lxml -c anaconda-cluster
+RUN conda create -y -q -n py26 coverage python=2.6 pytest requests apache-maven lxml -c anaconda-cluster
 RUN conda create -y -q -n py3 coverage python=3 pytest requests apache-maven lxml -c anaconda-cluster
 RUN /opt/anaconda/bin/pip install coveralls
+RUN /opt/anaconda/envs/py26/bin/pip install coveralls
 RUN /opt/anaconda/envs/py3/bin/pip install coveralls
 
 # Cloudera repositories

--- a/continuous_integration/coverage_test.sh
+++ b/continuous_integration/coverage_test.sh
@@ -1,2 +1,4 @@
-/opt/anaconda/bin/pip install pytest-cov
-/opt/anaconda/bin/py.test --cov=knit knit/tests --cov-report term-missing -s -vv
+ANACONDADIR=${1:-"/opt/anaconda"}
+
+$ANACONDADIR/bin/pip install pytest-cov
+$ANACONDADIR/bin/py.test --cov=knit knit/tests --cov-report term-missing -s -vv

--- a/knit/compatibility.py
+++ b/knit/compatibility.py
@@ -6,7 +6,29 @@ if sys.version_info < (3,):
     FileNotFoundError = IOError
     PermissionError = IOError
     from urlparse import urlparse
+    
 else:
     PermissionError = PermissionError
     FileNotFoundError = FileNotFoundError
     from urllib.parse import urlparse
+    
+    
+try:
+    from subprocess import check_output
+
+except ImportError:
+    import subprocess
+    def check_output(*popenargs, **kwargs):
+        """Backported from Python 2.7 as it's implemented as pure python on stdlib."""
+
+        process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            error = subprocess.CalledProcessError(retcode, cmd)
+            error.output = output
+            raise error
+        return output

--- a/knit/core.py
+++ b/knit/core.py
@@ -69,7 +69,7 @@ class Knit(object):
         os.environ['KNIT_HOME'] = self.KNIT_HOME
 
     def __str__(self):
-        return "Knit<NN={}:{};RM={}:{}>".format(self.nn, self.nn_port,
+        return "Knit<NN={0}:{1};RM={2}:{3}>".format(self.nn, self.nn_port,
                                                      self.rm, self.rm_port)
 
     __repr__ = __str__
@@ -108,11 +108,11 @@ class Knit(object):
             return conf['host'], conf['port']
 
         if self.rm != conf['host']:
-            msg = "Possible Resource Manager hostname mismatch.  Detected {}".format(conf['host'])
+            msg = "Possible Resource Manager hostname mismatch.  Detected {0}".format(conf['host'])
             raise HDFSConfigException(msg)
 
         if str(self.rm_port) != str(conf['port']):
-            msg = "Possible Resource Manager port mismatch.  Detected {}".format(conf['port'])
+            msg = "Possible Resource Manager port mismatch.  Detected {0}".format(conf['port'])
             raise HDFSConfigException(msg)
 
         return conf
@@ -148,11 +148,11 @@ class Knit(object):
             return conf['host'], conf['port']
 
         if self.nn != conf['host']:
-            msg = "Possible Namenode hostname mismatch.  Detected {}".format(conf['host'])
+            msg = "Possible Namenode hostname mismatch.  Detected {0}".format(conf['host'])
             raise HDFSConfigException(msg)
 
         if str(self.nn_port) != str(conf['port']):
-            msg = "Possible Namenode port mismatch.  Detected {}".format(conf['port'])
+            msg = "Possible Namenode port mismatch.  Detected {0}".format(conf['port'])
             raise HDFSConfigException(msg)
 
         return conf
@@ -200,7 +200,7 @@ class Knit(object):
             f = ','.join(files)
             args = args + ["--files", str(f)]
 
-        logger.debug("Running Command: {}".format(' '.join(args)))
+        logger.debug("Running Command: {0}".format(' '.join(args)))
         proc = Popen(args, stdout=PIPE, stderr=PIPE)
         out, err = proc.communicate()
 

--- a/knit/tests/test_conda_create.py
+++ b/knit/tests/test_conda_create.py
@@ -43,8 +43,11 @@ def test_full_create(c):
     assert os.path.getsize(env_zip) > 500000 # ensures zipfile has non-0 size
     assert zipfile.is_zipfile(env_zip)
 
-    with zipfile.ZipFile(env_zip, 'r') as f:
+    f = zipfile.ZipFile(env_zip, 'r')
+    try:
         assert f.getinfo('test_env/bin/python')
+    finally:
+        f.close()
 
 
 def test_find_env(c):

--- a/knit/tests/test_utils.py
+++ b/knit/tests/test_utils.py
@@ -15,10 +15,15 @@ inside_docker = check_docker
 
 
 def test_conf_parse():
-    assert 'hdfs://knit-host:9000' == conf_find(core_site, 'fs.defaultFS')
     assert '' == conf_find(core_site, 'FOO/BAR')
+
+    assert 'hdfs://knit-host:9000' == conf_find(core_site, 'fs.defaultFS')
+    conf = parse_xml(core_site, 'fs.defaultFS')
+    assert conf == {'port': 9000, 'host': 'knit-host'}
+
+    assert 'knit-host:8088' == conf_find(yarn_site, 'yarn.resourcemanager.webapp.address')
     conf = parse_xml(yarn_site, 'yarn.resourcemanager.webapp.address')
-    assert conf == {'port': '8088', 'host': 'knit-host'}
+    assert conf == {'port': 8088, 'host': 'knit-host'}
 
 
 def test_set_logging():

--- a/knit/yarn_api.py
+++ b/knit/yarn_api.py
@@ -17,7 +17,7 @@ def check_app_id(func):
         cls = args[0]
         app_id = args[1]
         if app_id not in cls.apps:
-            raise YARNException("{}: not a valid Application "
+            raise YARNException("{0}: not a valid Application "
                                 "Id".format(app_id))
         return func(*args, **kwargs)
     return wrapper
@@ -27,13 +27,13 @@ class YARNAPI(object):
     def __init__(self, rm, rm_port):
         self.rm = rm
         self.rm_port = rm_port
-        self.host_port = "{}:{}".format(self.rm, self.rm_port)
+        self.host_port = "{0}:{1}".format(self.rm, self.rm_port)
 
 
     @property
     def apps(self):
-        url = "http://{}/ws/v1/cluster/apps/".format(self.host_port)
-        logger.debug("Getting Resource Manager Info: {}".format(url))
+        url = "http://{0}/ws/v1/cluster/apps/".format(self.host_port)
+        logger.debug("Getting Resource Manager Info: {0}".format(url))
         r = requests.get(url)
         data = r.json()
         logger.debug(data)
@@ -68,9 +68,9 @@ class YARNAPI(object):
             out = shell_out(cmd)
             return str(out)
 
-        host_port = "{}:{}".format(self.rm, self.rm_port)
-        url = "http://{}/ws/v1/cluster/apps/{}".format(host_port, app_id)
-        logger.debug("Getting Resource Manager Info: {}".format(url))
+        host_port = "{0}:{1}".format(self.rm, self.rm_port)
+        url = "http://{0}/ws/v1/cluster/apps/{1}".format(host_port, app_id)
+        logger.debug("Getting Resource Manager Info: {0}".format(url))
         r = requests.get(url)
         data = r.json()
         logger.debug(data)
@@ -78,12 +78,12 @@ class YARNAPI(object):
         try:
             amHostHttpAddress = data['app']['amHostHttpAddress']
         except KeyError:
-            msg = "Local logs unavailable. State: {} finalStatus: {} Possibly check logs " \
+            msg = "Local logs unavailable. State: {0} finalStatus: {1} Possibly check logs " \
                   "with `yarn logs -applicationId`".format(data['app']['state'],
                                                            data['app']['finalStatus'])
             raise Exception(msg)
 
-        url = "http://{}/ws/v1/node/containers".format(amHostHttpAddress)
+        url = "http://{0}/ws/v1/node/containers".format(amHostHttpAddress)
         r = requests.get(url)
 
         data = r.json()['containers']
@@ -105,13 +105,13 @@ class YARNAPI(object):
             log=dict(nodeId=c['nodeId'])
 
             # grab stdout
-            url = "{}/stdout/?start=0".format(c['containerLogsLink'])
-            logger.debug("Gather stdout/stderr data from {}: {}".format(c['nodeId'], url))
+            url = "{0}/stdout/?start=0".format(c['containerLogsLink'])
+            logger.debug("Gather stdout/stderr data from {0}: {1}".format(c['nodeId'], url))
             r = requests.get(url)
             log['stdout'] = r.text
 
             # grab stderr
-            url = "{}/stderr/?start=0".format(c['containerLogsLink'])
+            url = "{0}/stderr/?start=0".format(c['containerLogsLink'])
             r = requests.get(url)
             log['stderr'] = r.text
 
@@ -133,9 +133,9 @@ class YARNAPI(object):
         log: dictionary
             status of application
         """
-        host_port = "{}:{}".format(self.rm, self.rm_port)
-        url = "http://{}/ws/v1/cluster/apps/{}".format(host_port, app_id)
-        logger.debug("Getting Application Info: {}".format(url))
+        host_port = "{0}:{1}".format(self.rm, self.rm_port)
+        url = "http://{0}/ws/v1/cluster/apps/{1}".format(host_port, app_id)
+        logger.debug("Getting Application Info: {0}".format(url))
         r = requests.get(url)
         data = r.json()
 


### PR DESCRIPTION
Removed an unused import which wasn't available in Python 2.6, and modified all string formatting to included a numeric index required by Python 2.6.
