### PR TITLE
Use HDFS_KNIT_DIR everywhere

### DIFF
--- a/knit_jvm/src/main/scala/io/continuum/knit/Utils.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/Utils.scala
@@ -70,7 +70,7 @@ object Utils extends Logging {
   def uploadFile(filePath: String)(implicit conf: YarnConfiguration) = {
     val fs = FileSystem.get(conf)
     val stagingDir = ".knitDeps"
-    val stagingDirPath = new Path(fs.getHomeDirectory(), stagingDir)
+    val stagingDirPath = new Path(sys.env("HDFS_KNIT_DIR"), stagingDir)
     val replicationFactor = sys.env("REPLICATION_FACTOR").toShort
 
     val FILE_PATH = new File(filePath).getAbsolutePath()


### PR DESCRIPTION
Previously this wasn't used everywhere, which lead to mismatch between upload and download paths for environments.

At some point this should probably all be refactored to not repeat this path handling everywhere.

I also didn't add any tests because I wasn't sure how the test infrastructure for this repo worked.