### PR TITLE
Make lang passed from DaskYarnCluster

### DIFF
--- a/knit/core.py
+++ b/knit/core.py
@@ -101,6 +101,7 @@ class Knit(object):
         self.upload_always = upload_always
         self.hdfs_home = hdfs_home or self.conf.get('dfs.user.home.base.dir',
                                                '/user/' + self.conf.get('user', conf['user']))
+        self.lang = self.conf.get('lang', 'C.UTF-8')
 
         # must set KNIT_HOME ENV for YARN App
         os.environ['KNIT_HOME'] = self.KNIT_HOME
@@ -169,8 +170,7 @@ class Knit(object):
                                     'capacity (%iMB)' % (need, cap))
 
     def start(self, cmd, num_containers=1, virtual_cores=1, memory=128, env="",
-              files=[], app_name="knit", queue="default", checks=True,
-              lang='C.UTF-8'):
+              files=[], app_name="knit", queue="default", checks=True):
         """
         Method to start a yarn app with a distributed shell
 
@@ -201,9 +201,6 @@ class Knit(object):
             RM Queue to use while scheduling (default: "default")
         checks: bool=True
             Whether to run pre-flight checks before submitting app to YARN
-        lang: str
-            Environment variable language setting, required for ``click`` to
-            successfully read from the shell.
 
         Returns
         -------
@@ -272,8 +269,9 @@ class Knit(object):
         self.client = gateway.entry_point
         self.client_gateway = gateway
         upload = self.check_env_needs_upload(env)
+
         self.app_id = self.client.start(env, ','.join(files), app_name, queue,
-                                        str(upload), lang)
+                                        str(upload), self.lang)
 
         long_timeout = 100
         master_rpcport = -1

--- a/knit/core.py
+++ b/knit/core.py
@@ -51,6 +51,9 @@ class Knit(object):
         Resource Manager hostname
     rm_port: int
         Resource Manager port (default: 8088)
+    lang: str
+        Environment variable language setting, required for ``click`` to
+        successfully read from the shell. (default: 'C-UTF-8')
     user: str ('root')
         The user name from point of view of HDFS. This is only used when
         checking for the existence of knit files on HDFS, since they are stored

--- a/knit/core.py
+++ b/knit/core.py
@@ -53,7 +53,7 @@ class Knit(object):
         Resource Manager port (default: 8088)
     lang: str
         Environment variable language setting, required for ``click`` to
-        successfully read from the shell. (default: 'C-UTF-8')
+        successfully read from the shell. (default: 'C.UTF-8')
     user: str ('root')
         The user name from point of view of HDFS. This is only used when
         checking for the existence of knit files on HDFS, since they are stored

--- a/knit/dask_yarn.py
+++ b/knit/dask_yarn.py
@@ -27,7 +27,7 @@ class DaskYARNCluster(object):
     
     Parameters
     ----------
-    nn, nn_port, rm, rm_port, user, autodetect: see knit.Knit
+    nn, nn_port, rm, rm_port, user, autodetect, lang: see knit.Knit
     env: str or None
         If provided, the path of a zipped conda env to put in containers
     packages: list of str

--- a/knit/tests/test_core.py
+++ b/knit/tests/test_core.py
@@ -25,7 +25,7 @@ def wait_for_status(k, status, timeout=30):
 
     time.sleep(1)
     return timeout > 0
-        
+
 
 def wait_for_containers(k, running_containers, timeout=30):
     cur_running_containers = k.status()['runningContainers']
@@ -238,12 +238,15 @@ def test_yarn_kill_status(k):
 
 def test_lang(k):
     cmd = "env"
-    k.start(cmd, num_containers=1, lang='en_US.utf-8')
+    orig_lang = k.lang
+    k.lang = 'en_US.utf-8'
+    k.start(cmd, num_containers=1)
 
     wait_for_status(k, 'FINISHED')
     time.sleep(2)
     out = k.logs()
     assert "LANG=en_US.utf-8" in str(out)
+    k.lang = orig_lang
 
 
 def test_logs(k):


### PR DESCRIPTION
The lang parameter wasn't called when passed to `DaskYarnCluster`, so this puts lang as a parameter that can be passed to `Knit.__init__`. The problem is we have removed the documentation in the docstring and the test is a little hacky. So, I think this solution will work, but there is probably a better solution.