### PR TITLE
Cleanup configuration handling

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -22,7 +22,9 @@ Connection with hdfs3
 
 Some operations, such as checking for uploaded conda environments, optionally make use of
 `hdfs3`_. The configuration system, above, and that for hdfs3 are very similar, so you may
-well not have to make any extra steps to get this working correctly for you. However, you may
+well not have to make any extra steps to get this working correctly for you; normally the
+files defining values for Yarn should be in the same location as those for HDFS. However,
+you may
 well wish to be more explicit about the configuration of the HDFileSystem instance you want
 knit to use. In this case, create the instance as usual, and assign it to the Knit instance
 as follows
@@ -30,18 +32,12 @@ as follows
 .. code-block:: python
 
    hdfs = HDFileSystem(...)
-   k = Knit(...)
-   k._hdfs = hdfs
+   k = Knit(..., hdfs=hdfs)
 
 or, similarly for a Dask cluster
 
 .. code-block:: python
 
-   cluster = DaskYARNCluster(...)
-   cluster.knit._hdfs = hdfs
-
-The special environment variable ``LIBHDFS3_CONF`` will be automatically set when parsing
-the config files, if possible. Since the library is only loaded upon the first instantiation
-of a HDFileSystem, you still have the option to change its value in ``os.environ``.
+   cluster = DaskYARNCluster(..., hdfs=hdfs)
 
 .. _hdfs3: http://hdfs3.readthedocs.io/en/latest/

--- a/knit/conf.py
+++ b/knit/conf.py
@@ -58,7 +58,8 @@ DEFAULTS = {'nn': 'localhost',
             'rm': 'localhost',
             'rm_port': 8088,
             'rm_port_https': 8090,
-            'replication_factor': 3}
+            'replication_factor': 3,
+            'user': current_user()}
 
 
 def get_host_port(addr):
@@ -206,7 +207,11 @@ def load_config():
 
     if _cached_config is None:
         # Find the configuration files
-        paths = find_config_files()
+        try:
+            paths = find_config_files()
+        except ValueError:
+            _cached_config = DEFAULTS.copy()
+            return DEFAULTS.copy()
 
         # Ensure that LIBHDFS3_CONF points to the hdfs config file
         os.environ['LIBHDFS3_CONF'] = paths['hdfs']

--- a/knit/conf.py
+++ b/knit/conf.py
@@ -8,7 +8,36 @@ from __future__ import absolute_import
 
 import os
 import re
-import warnings
+try:
+    from urllib.parse import urlsplit
+except ImportError:
+    from urlparse import urlsplit
+
+
+__all__ = ('get_config', 'load_config', 'reset_config_cache')
+
+
+def get_config(autodetect=True, pars=None, **kwargs):
+    """Get configuration dictionary.
+
+    Build up a configuration dictionary based on configuration files and
+    overrides.
+
+    Parameters
+    ----------
+    autodetect : bool, optional
+        If True (default) configuration is read from files on disk. Otherwise
+        only specified configuration parameters are used.
+    pars : dict, optional
+        Extra parameters to use for overriding
+    **kwargs
+        Extra parameters to use for overriding
+    """
+    config = load_config() if autodetect else {}
+    if pars:
+        config.update(**pars)
+    config.update(**kwargs)
+    return config
 
 
 def current_user():
@@ -19,90 +48,82 @@ def current_user():
         import getpass
         return getpass.getuser()
 
-DEFAULT_USER = current_user()
+
 java_lib_dir = os.path.join(os.path.dirname(__file__), "java_libs")
 DEFAULT_KNIT_HOME = os.environ.get('KNIT_HOME') or java_lib_dir
 
 # standard defaults
-conf_defaults = {'nn': 'localhost', 'nn_port': 8020, 'rm': 'localhost',
-                 'rm_port': 8088, 'rm_port_https': 8090,
-                 'replication_factor': 3}
-conf = conf_defaults.copy()
+DEFAULTS = {'nn': 'localhost',
+            'nn_port': 8020,
+            'rm': 'localhost',
+            'rm_port': 8088,
+            'rm_port_https': 8090,
+            'replication_factor': 3}
 
 
-def hdfs_conf(confd, more_files=None):
-    """ Load HDFS config from default locations. 
+def get_host_port(addr):
+    """Infer a host & port from a given addr"""
+    parsed = urlsplit(addr)
+    if parsed.hostname:
+        host = parsed.hostname
+        port = parsed.port
+    elif ':' in parsed.path:
+        host, port = parsed.path.split(':', 1)
+        port = int(port)
+    else:
+        host = parsed.path
+        port = None
+    return host, port
 
-    Parameters
-    ----------
-    confd: str
-        Directory location to search in
-    more_files: list of str or None
-        If given, additional filenames to query
-    """
-    files = ['core-site.xml', 'hdfs-site.xml']
-    if more_files:
-        files.extend(more_files)
-    c = {'user': DEFAULT_USER}
-    for afile in files:
-        try:
-            c.update(conf_to_dict(os.sep.join([confd, afile])))
-        except (IOError, OSError):
-            pass
-    if not c:
-        # no config files here
-        return
-    if 'fs.defaultFS' in c and c['fs.defaultFS'].startswith('hdfs'):
-        # default FS in 'core'
-        text = c['fs.defaultFS'].strip('hdfs://')
-        host = text.split(':', 1)[0]
-        port = text.split(':', 1)[1:]
-        if host:
-            c['nn'] = host
-        if port:
-            c['nn_port'] = int(port[0])
-    if 'dfs.namenode.rpc-address' in c:
-        # name node address
-        text = c['dfs.namenode.rpc-address']
-        host = text.split(':', 1)[0]
-        port = text.split(':', 1)[1:]
-        if host:
-            c['nn'] = host
-        if port:
-            c['nn_port'] = int(port[0])
-    if c.get("dfs.nameservices", None):
+
+def infer_extra_params(config):
+    """Given a config dict, infer the values of some extra fields"""
+    user = current_user()
+
+    replication_factor = config.get('dfs.replication',
+                                    DEFAULTS['replication_factor'])
+
+    # namenode and port
+    if 'dfs.nameservices' in config:
         # HA override
-        c['nn'] = c["dfs.nameservices"].split(',', 1)[0]
-        c['nn_port'] = None
-    if 'dfs.replication' in c:
-        c['replication_factor'] = c['dfs.replication']
+        nn_text = config['dfs.nameservices'].split(',', 1)[0]
+        nn, nn_port = get_host_port(nn_text)
+    elif 'dfs.namenode.rpc-address' in config:
+        # name node address
+        nn, nn_port = get_host_port(config['dfs.namenode.rpc-address'])
+    elif 'fs.defaultFS' in config:
+        # default FS in 'core'
+        nn, nn_port = get_host_port(config['fs.defaultFS'])
     else:
-        c['replication_factor'] = conf_defaults['replication_factor']
-    if 'yarn.resourcemanager.webapp.address' in c:
-        c['rm'], c['rm_port'] = c[
-            'yarn.resourcemanager.webapp.address'].split(':')
-    elif 'yarn.resourcemanager.hostname' in c:
-        c['rm'] = c['yarn.resourcemanager.hostname']
-        c['rm_port'] = conf_defaults['rm_port']
+        nn = DEFAULTS['nn']
+        nn_port = DEFAULTS['nn_port']
+
+    # resourcemanager and port
+    if 'yarn.resourcemanager.webapp.address' in config:
+        rm_addr = config['yarn.resourcemanager.webapp.address']
+        rm, rm_port = get_host_port(rm_addr)
     else:
-        c['rm'] = conf_defaults['rm']
-        c['rm_port'] = conf_defaults['rm_port']
-    if 'yarn.resourcemanager.webapp.https.address' in c:
-        c['rm'], c['rm_port_https'] = c[
-            'yarn.resourcemanager.webapp.https.address'].split(':')
+        rm = config.get('yarn.resourcemanager.hostname', DEFAULTS['rm'])
+        rm_port = DEFAULTS['rm_port']
+
+    # resourcemanager https port
+    if 'yarn.resourcemanager.webapp.https.address' in config:
+        rm_https_addr = config['yarn.resourcemanager.webapp.https.address']
+        rm_port_https = get_host_port(rm_https_addr)[1]
     else:
-        c['rm_port_https'] = conf_defaults['rm_port_https']
-    conf.clear()
-    conf.update(c)
+        rm_port_https = DEFAULTS['rm_port_https']
+
+    return {'user': user,
+            'replication_factor': replication_factor,
+            'nn': nn,
+            'nn_port': nn_port,
+            'rm': rm,
+            'rm_port': rm_port,
+            'rm_port_https': rm_port_https}
 
 
-def reset_to_defaults():
-    conf.clear()
-    conf.update(conf_defaults)
-
-
-def conf_to_dict(fname):
-    """ Read a hdfs-site.xml style conf file, produces dictionary """
+def config_to_dict(fname):
+    """ Read a *-site.xml style conf file, produces dictionary """
     name_match = re.compile("<name>(.*?)</name>")
     val_match = re.compile("<value>(.*?)</value>")
     conf = {}
@@ -117,33 +138,95 @@ def conf_to_dict(fname):
     return conf
 
 
-def guess_config():
-    """ Look for config files in common places """
-    d = None
+def error_if_path_missing(envvar):
+    """Raise a ValueError if the path specified by an ENVVAR is missing"""
+    path = os.environ[envvar]
+    if not os.path.exists(path):
+        raise ValueError("Environment variable `%s` points to "
+                         "non-existant location" % envvar)
+
+
+def find_config_files():
+    """Look for config files in common places"""
+
+    hdfs_site = 'hdfs-site.xml'
+
+    # Find the configuration directory
     if 'LIBHDFS3_CONF' in os.environ:
-        fdir, fn = os.path.split(os.environ['LIBHDFS3_CONF'])
-        hdfs_conf(fdir, more_files=[fn, 'yarn-site.xml'])
-        if not os.path.exists(os.environ['LIBHDFS3_CONF']):
-            del os.environ['LIBHDFS3_CONF']
-        return
+        error_if_path_missing('LIBHDFS3_CONF')
+        confd, hdfs_site = os.path.split(os.environ['LIBHDFS3_CONF'])
     elif 'HADOOP_CONF_DIR' in os.environ:
-        d = os.environ['HADOOP_CONF_DIR']
+        error_if_path_missing('HADOOP_CONF_DIR')
+        confd = os.environ['HADOOP_CONF_DIR']
     elif 'HADOOP_INSTALL' in os.environ:
-        d = os.environ['HADOOP_INSTALL'] + '/hadoop/conf'
-    if d is None:
+        error_if_path_missing('HADOOP_INSTALL')
+        confd = os.environ['HADOOP_INSTALL'] + '/hadoop/conf'
+    else:
         # list of potential typical system locations
         for loc in ['/etc/hadoop/conf']:
             if os.path.exists(loc):
                 fns = os.listdir(loc)
-                if 'hdfs-site.xml' in fns:
-                    d = loc
+                if hdfs_site in fns:
+                    confd = loc
                     break
-    if d is None:
-        # fallback: local dir
-        d = os.getcwd()
-    hdfs_conf(d, more_files=['yarn-site.xml'])
-    if os.path.exists(os.path.join(d, 'hdfs-site.xml')):
-        os.environ['LIBHDFS3_CONF'] = os.path.join(d, 'hdfs-site.xml')
+        else:
+            # fallback: local dir
+            confd = os.getcwd()
+
+    configs = {'yarn': 'yarn-site.xml',
+               'core': 'core-site.xml',
+               'hdfs': hdfs_site}
+    paths = {}
+
+    for name, f in configs.items():
+        full_path = os.path.join(confd, f)
+        if not os.path.exists(full_path):
+            raise ValueError("Failed to load `%s` configuration file at "
+                             "`%s`, file not found" % (name, full_path))
+        paths[name] = full_path
+
+    return paths
 
 
-guess_config()
+# The cached configuration
+_cached_config = None
+
+
+def load_config():
+    """Load configuration from config files.
+
+    Will error if configuration files aren't found.
+
+    Returns
+    -------
+    config : dict
+        The configuration dictionary.
+    """
+    global _cached_config
+
+    if _cached_config is None:
+        # Find the configuration files
+        paths = find_config_files()
+
+        # Ensure that LIBHDFS3_CONF points to the hdfs config file
+        os.environ['LIBHDFS3_CONF'] = paths['hdfs']
+
+        # Load and merge all config files
+        config = {}
+        for path in paths.values():
+            config.update(config_to_dict(path))
+
+        # Determine extra parameters
+        config.update(infer_extra_params(config))
+
+        _cached_config = config
+
+    return _cached_config.copy()
+
+
+def reset_config_cache():
+    """Reset the configuration cache.
+
+    The configuration will be recomputed on the next call to `load_config`."""
+    global _cached_config
+    _cached_config = None

--- a/knit/core.py
+++ b/knit/core.py
@@ -12,7 +12,7 @@ from subprocess import Popen, PIPE, call
 import struct
 import time
 
-from .conf import conf, DEFAULT_KNIT_HOME
+from .conf import get_config, DEFAULT_KNIT_HOME
 from .env import CondaCreator
 from .exceptions import KnitException, YARNException
 from .yarn_api import YARNAPI
@@ -89,10 +89,7 @@ class Knit(object):
     def __init__(self, autodetect=True, upload_always=False, hdfs_home=None,
                  knit_home=DEFAULT_KNIT_HOME, pars=None, **kwargs):
 
-        self.conf = conf.copy() if autodetect else {}
-        if pars:
-            self.conf.update(pars)
-        self.conf.update(kwargs)
+        self.conf = get_config(autodetect=autodetect, pars=pars, **kwargs)
 
         if self.conf.get('yarn.http.policy', '').upper() == "HTTPS_ONLY":
             self.yarn_api = YARNAPI(self.conf['rm'], self.conf['rm_port_https'],

--- a/knit/core.py
+++ b/knit/core.py
@@ -96,8 +96,8 @@ class Knit(object):
 
         self.KNIT_HOME = knit_home
         self.upload_always = upload_always
-        self.hdfs_home = hdfs_home or self.conf.get('dfs.user.home.base.dir',
-                                               '/user/' + self.conf.get('user', conf['user']))
+        self.hdfs_home = hdfs_home or self.conf.get(
+            'dfs.user.home.base.dir', '/user/' + self.conf['user'])
 
         # must set KNIT_HOME ENV for YARN App
         os.environ['KNIT_HOME'] = self.KNIT_HOME

--- a/knit/core.py
+++ b/knit/core.py
@@ -99,9 +99,9 @@ class Knit(object):
 
         self.KNIT_HOME = knit_home
         self.upload_always = upload_always
-        self.hdfs_home = hdfs_home or self.conf.get('dfs.user.home.base.dir',
-                                               '/user/' + self.conf.get('user', conf['user']))
         self.lang = self.conf.get('lang', 'C.UTF-8')
+        self.hdfs_home = hdfs_home or self.conf.get(
+            'dfs.user.home.base.dir', '/user/' + self.conf['user'])
 
         # must set KNIT_HOME ENV for YARN App
         os.environ['KNIT_HOME'] = self.KNIT_HOME

--- a/knit/core.py
+++ b/knit/core.py
@@ -12,7 +12,7 @@ from subprocess import Popen, PIPE, call
 import struct
 import time
 
-from .conf import conf, DEFAULT_KNIT_HOME
+from .conf import get_config, DEFAULT_KNIT_HOME
 from .env import CondaCreator
 from .exceptions import KnitException, YARNException
 from .yarn_api import YARNAPI
@@ -86,10 +86,7 @@ class Knit(object):
     def __init__(self, autodetect=True, upload_always=False, hdfs_home=None,
                  knit_home=DEFAULT_KNIT_HOME, pars=None, **kwargs):
 
-        self.conf = conf.copy() if autodetect else {}
-        if pars:
-            self.conf.update(pars)
-        self.conf.update(kwargs)
+        self.conf = get_config(autodetect=autodetect, pars=pars, **kwargs)
 
         if self.conf.get('yarn.http.policy', '').upper() == "HTTPS_ONLY":
             self.yarn_api = YARNAPI(self.conf['rm'], self.conf['rm_port_https'],

--- a/knit/tests/test_conf.py
+++ b/knit/tests/test_conf.py
@@ -26,26 +26,6 @@ def test_infer_extra_params():
     extra = infer_extra_params({'dfs.replication': 10})
     assert extra['replication_factor'] == 10
 
-    # == namenode and port ==
-    # HA takes priority
-    config = {'dfs.nameservices': 'priority1.com,foo.baz.com',
-              'dfs.namenode.rpc-address': 'priority2.com:8080',
-              'fs.defaultFS': 'hdfs://priority3.com:8081'}
-    extra = infer_extra_params(config)
-    assert extra['nn'] == 'priority1.com'
-    assert extra['nn_port'] is None
-    # Next is rpc-address
-    config = {'dfs.namenode.rpc-address': 'priority2.com:8080',
-              'fs.defaultFS': 'hdfs://priority3.com:8081'}
-    extra = infer_extra_params(config)
-    assert extra['nn'] == 'priority2.com'
-    assert extra['nn_port'] == 8080
-    # Next is defaultFS
-    config = {'fs.defaultFS': 'hdfs://priority3.com:8081'}
-    extra = infer_extra_params(config)
-    assert extra['nn'] == 'priority3.com'
-    assert extra['nn_port'] == 8081
-
     # == resourcemanager and port ==
     # take port from webapp.address if provided
     config = {'yarn.resourcemanager.webapp.address': 'priority1.com:1111',
@@ -66,8 +46,7 @@ def test_infer_extra_params():
 
 
 def test_get_config():
-    kwargs = dict(nn="pi", nn_port=31415, rm="e", rm_port=27182,
-                  replication_factor=1)
+    kwargs = dict(rm="e", rm_port=27182, replication_factor=1)
     config = get_config(autodetect=False, **kwargs)
     for k, v in kwargs.items():
         assert config[k] == v

--- a/knit/tests/test_conf.py
+++ b/knit/tests/test_conf.py
@@ -20,7 +20,6 @@ def test_get_host_port():
 def test_infer_extra_params():
     # == defaults ==
     extra = infer_extra_params({})
-    assert extra.pop('user')
     assert extra == DEFAULTS
 
     # == replication_factor ==

--- a/knit/tests/test_conf.py
+++ b/knit/tests/test_conf.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import, print_function
+
+from knit.conf import get_host_port, infer_extra_params, DEFAULTS, get_config
+
+
+def test_get_host_port():
+    host, port = get_host_port('hdfs://foo.bar.com:8080')
+    assert host == 'foo.bar.com'
+    assert port == 8080
+
+    host, port = get_host_port('foo.bar.com:8080')
+    assert host == 'foo.bar.com'
+    assert port == 8080
+
+    host, port = get_host_port('foo.bar.com')
+    assert host == 'foo.bar.com'
+    assert port is None
+
+
+def test_infer_extra_params():
+    # == defaults ==
+    extra = infer_extra_params({})
+    assert extra.pop('user')
+    assert extra == DEFAULTS
+
+    # == replication_factor ==
+    extra = infer_extra_params({'dfs.replication': 10})
+    assert extra['replication_factor'] == 10
+
+    # == namenode and port ==
+    # HA takes priority
+    config = {'dfs.nameservices': 'priority1.com,foo.baz.com',
+              'dfs.namenode.rpc-address': 'priority2.com:8080',
+              'fs.defaultFS': 'hdfs://priority3.com:8081'}
+    extra = infer_extra_params(config)
+    assert extra['nn'] == 'priority1.com'
+    assert extra['nn_port'] is None
+    # Next is rpc-address
+    config = {'dfs.namenode.rpc-address': 'priority2.com:8080',
+              'fs.defaultFS': 'hdfs://priority3.com:8081'}
+    extra = infer_extra_params(config)
+    assert extra['nn'] == 'priority2.com'
+    assert extra['nn_port'] == 8080
+    # Next is defaultFS
+    config = {'fs.defaultFS': 'hdfs://priority3.com:8081'}
+    extra = infer_extra_params(config)
+    assert extra['nn'] == 'priority3.com'
+    assert extra['nn_port'] == 8081
+
+    # == resourcemanager and port ==
+    # take port from webapp.address if provided
+    config = {'yarn.resourcemanager.webapp.address': 'priority1.com:1111',
+              'yarn.resourcemanager.hostname': 'priority2.com'}
+    extra = infer_extra_params(config)
+    assert extra['rm'] == 'priority1.com'
+    assert extra['rm_port'] == 1111
+    # Fallback to hostname and default port
+    config = {'yarn.resourcemanager.hostname': 'priority2.com'}
+    extra = infer_extra_params(config)
+    assert extra['rm'] == 'priority2.com'
+    assert extra['rm_port'] == DEFAULTS['rm_port']
+
+    # == resourcemanager https port ==
+    config = {'yarn.resourcemanager.webapp.https.address': 'address.com:1111'}
+    extra = infer_extra_params(config)
+    assert extra['rm_port_https'] == 1111
+
+
+def test_get_config():
+    kwargs = dict(nn="pi", nn_port=31415, rm="e", rm_port=27182,
+                  replication_factor=1)
+    config = get_config(autodetect=False, **kwargs)
+    for k, v in kwargs.items():
+        assert config[k] == v
+    # Just specified kwargs
+    assert 'user' not in config
+
+    config = get_config(**kwargs)
+    for k, v in kwargs.items():
+        assert config[k] == v
+    # Not just specified kwargs
+    assert 'user' in config

--- a/knit/tests/test_dask.py
+++ b/knit/tests/test_dask.py
@@ -14,7 +14,6 @@ pytest.importorskip('dask')
 import dask.distributed
 from knit.dask_yarn import DaskYARNCluster
 from knit import CondaCreator, Knit
-from knit.conf import conf, guess_config
 from dask.distributed import Client
 from distributed.utils_test import loop
 
@@ -37,25 +36,6 @@ def timeout(seconds=10, error_message=os.strerror(errno.ETIME)):
 
     return decorator
 
-
-def test_knit_config():
-    cluster = DaskYARNCluster(nn="pi", nn_port=31415, rm="e", rm_port=27182,
-                              autodetect=False, replication_factor=1)
-    str(cluster) == 'Knit<NN=pi:31415;RM=e:27182>'
-    cluster = DaskYARNCluster(nn="pi", nn_port=31415, rm="e", rm_port=27182,
-                              autodetect=True, replication_factor=1)
-    str(cluster) == 'Knit<NN=pi:31415;RM=e:27182>'
-
-    try:
-        conf['nn'] = 'nothost'
-        d = DaskYARNCluster(autodetect=True, replication_factor=1)
-        assert d.knit.conf['nn'] == 'nothost'
-
-        d = DaskYARNCluster(autodetect=True, nn='oi', replication_factor=1)
-        assert d.knit.conf['nn'] == 'oi'
-
-    finally:
-        guess_config()
 
 python_version = '%d.%d' % (sys.version_info.major, sys.version_info.minor)
 python_pkg = 'python=%s' % python_version


### PR DESCRIPTION
- Fix bug in inferring namenode host
- Cleanup logic to make config location inference clearer
- Cleanup logic to make parameter inference (e.g. namenode host) clearer
- Add tests for inference