### PR TITLE
Resources generalisation in knit

### DIFF
--- a/knit/__init__.py
+++ b/knit/__init__.py
@@ -3,7 +3,7 @@ import warnings
 
 from .utils import *
 from .core import *
-from .env import CondaCreator
+from .env import CondaCreator, zip_path
 from .yarn_api import YARNAPI
 try:
     from .dask_yarn import DaskYARNCluster

--- a/knit/core.py
+++ b/knit/core.py
@@ -90,7 +90,7 @@ class Knit(object):
 
     JAR_FILE = "knit-1.0-SNAPSHOT.jar"
     JAVA_APP = "io.continuum.knit.Client"
-    instances = weakref.WeakSet()
+    _instances = weakref.WeakSet()
 
     def __init__(self, autodetect=True, upload_always=False, hdfs_home=None,
                  knit_home=DEFAULT_KNIT_HOME, hdfs=None, pars=None,
@@ -206,7 +206,9 @@ class Knit(object):
             uploading. Otherwise, if hdfs3 is installed, existence of the
             file on HDFS will be checked to see if upload is needed.
             Files ending with `.zip` will be decompressed in the
-            container before launch.
+            container before launch as a directory with the same name as the
+            file: if myarc.zip contains files inside a directory stuff/, to
+            the container they will appear at ./myarc.zip/stuff/* .
         envvars: dict
             Environment variables to pass to AM *and* workers. Both keys
             and values must be strings only.
@@ -534,7 +536,7 @@ class Knit(object):
     def list_envs(self):
         """List knit conda environments already in HDFS
         
-        Looks staging directory for zip-files
+        Looks in staging directory for zip-files
         
         Returns: list of dict
             Details for each zip-file."""
@@ -563,9 +565,9 @@ class Knit(object):
             return True
 
     @classmethod
-    def cleanup(cls):
+    def _cleanup(cls):
         # called on program exit to destroy lingering connections/apps
         for instance in cls.instances:
             instance.kill()
 
-atexit.register(Knit.cleanup)
+atexit.register(Knit._cleanup)

--- a/knit/core.py
+++ b/knit/core.py
@@ -444,7 +444,7 @@ class Knit(object):
     def print_logs(self, shell=False):
         """print out a more console-friendly version of logs()"""
         for l, v in self.logs(shell).items():
-            print('Container ', l, ', id ', v.get('id', 'None'), '\n')
+            print('\n### Container ', l, ', id ', v.get('id', 'None'), ' ###\n')
             for part in ['stdout', 'stderr']:
                 print('##', part, '##')
                 print(v[part])

--- a/knit/core.py
+++ b/knit/core.py
@@ -567,7 +567,7 @@ class Knit(object):
     @classmethod
     def _cleanup(cls):
         # called on program exit to destroy lingering connections/apps
-        for instance in cls.instances:
+        for instance in cls._instances:
             instance.kill()
 
 atexit.register(Knit._cleanup)

--- a/knit/core.py
+++ b/knit/core.py
@@ -121,7 +121,7 @@ class Knit(object):
         self.app_id = None
         self.proc = None
         self.hdfs = hdfs
-        self.instances.add(self)
+        self._instances.add(self)
 
     def __str__(self):
         return "Knit<RM={0}:{1}>".format(self.conf['rm'], self.conf['rm_port'])

--- a/knit/dask_yarn.py
+++ b/knit/dask_yarn.py
@@ -7,7 +7,7 @@ from hashlib import sha1
 from tornado import gen
 from toolz import unique
 
-from knit import Knit, CondaCreator
+from knit import Knit, CondaCreator, zip_path
 from distributed import LocalCluster
 
 global_packages = ['dask>=0.14', 'distributed>=1.16']
@@ -53,7 +53,7 @@ class DaskYARNCluster(object):
         self.env = env
         self.application_master_container = None
         self.app_id = None
-        self.channels = channels
+        self.channels = channels or []
         self.conda_pars = conda_pars
 
         try:
@@ -96,35 +96,35 @@ class DaskYARNCluster(object):
         -------
         YARN application ID.
         """
-        c = CondaCreator(channels=self.channels, **(self.conda_pars or {}))
         if self.env is None:
+            c = CondaCreator(channels=self.channels, **(self.conda_pars or {}))
             env_name = 'dask-' + sha1(
-                '-'.join(self.packages).encode()).hexdigest()
+                '-'.join(self.packages + self.channels).encode()).hexdigest()
             env_path = os.path.join(c.conda_envs, env_name)
             if os.path.exists(env_path + '.zip'):
                 # zipfile exists, ready to upload
                 self.env = env_path + '.zip'
             elif os.path.exists(env_path):
                 # environment exists, can zip and upload
-                c.zip_env(env_path)
-                self.env = env_path + '.zip'
+                self.env = zip_path(env_path)
             else:
                 # create env from scratch
                 self.env = c.create_env(env_name=env_name,
                                         packages=self.packages)
         elif not self.env.endswith('.zip'):
             # given env directory, so zip it
-            c.zip_env(self.env)
-            self.env = self.env + '.zip'
+            self.env = zip_path(self.env)
 
         # TODO: memory should not be total available?
-        command = '$PYTHON_BIN $CONDA_PREFIX/bin/dask-worker --nprocs=1 ' \
-                  '--nthreads=%d --memory-limit=%d %s > ' \
-                  '/tmp/worker-log.out 2> /tmp/worker-log.err' % (
-                      cpus, memory * 1e6,
-                      self.local_cluster.scheduler.address)
+        bn = os.path.basename(self.env)
+        pref = bn + '/' + bn[:-4]  # like myenv.zip/myenv
+        command = ('{pref}/bin/python {pref}/bin/dask-worker --nprocs=1 '
+                   '--nthreads={cpus} --memory-limit={mem} --no-bokeh {addr} > '
+                   '/tmp/worker-log.out 2> /tmp/worker-log.err'
+                   ''.format(cpus=cpus, mem=memory * 1e6, pref=pref,
+                             addr=self.local_cluster.scheduler.address))
 
-        app_id = self.knit.start(command, env=self.env,
+        app_id = self.knit.start(command, files=[self.env],
                                  num_containers=n_workers, virtual_cores=cpus,
                                  memory=memory, checks=checks, **kwargs)
         self.app_id = app_id

--- a/knit/dask_yarn.py
+++ b/knit/dask_yarn.py
@@ -119,8 +119,7 @@ class DaskYARNCluster(object):
         bn = os.path.basename(self.env)
         pref = bn + '/' + bn[:-4]  # like myenv.zip/myenv
         command = ('{pref}/bin/python {pref}/bin/dask-worker --nprocs=1 '
-                   '--nthreads={cpus} --memory-limit={mem} --no-bokeh {addr} > '
-                   '/tmp/worker-log.out 2> /tmp/worker-log.err'
+                   '--nthreads={cpus} --memory-limit={mem} --no-bokeh {addr} '
                    ''.format(cpus=cpus, mem=memory * 1e6, pref=pref,
                              addr=self.local_cluster.scheduler.address))
 

--- a/knit/dask_yarn.py
+++ b/knit/dask_yarn.py
@@ -117,7 +117,8 @@ class DaskYARNCluster(object):
 
         # TODO: memory should not be total available?
         bn = os.path.basename(self.env)
-        pref = bn + '/' + bn[:-4]  # like myenv.zip/myenv
+        pathsep = '/'  # assume execution is always on posix
+        pref = pathsep.join([bn, os.path.splitext(bn)])  # like myenv.zip/myenv
         command = ('{pref}/bin/python {pref}/bin/dask-worker --nprocs=1 '
                    '--nthreads={cpus} --memory-limit={mem} --no-bokeh {addr} '
                    ''.format(cpus=cpus, mem=memory * 1e6, pref=pref,

--- a/knit/dask_yarn.py
+++ b/knit/dask_yarn.py
@@ -118,7 +118,7 @@ class DaskYARNCluster(object):
         # TODO: memory should not be total available?
         bn = os.path.basename(self.env)
         pathsep = '/'  # assume execution is always on posix
-        pref = pathsep.join([bn, os.path.splitext(bn)])  # like myenv.zip/myenv
+        pref = pathsep.join([bn, os.path.splitext(bn)[0]])  # like myenv.zip/myenv
         command = ('{pref}/bin/python {pref}/bin/dask-worker --nprocs=1 '
                    '--nthreads={cpus} --memory-limit={mem} --no-bokeh {addr} '
                    ''.format(cpus=cpus, mem=memory * 1e6, pref=pref,

--- a/knit/env.py
+++ b/knit/env.py
@@ -216,41 +216,45 @@ class CondaCreator(object):
         else:
             env_path = self._create_env(env_name, packages, remove)
 
-        return self.zip_env(env_path)
+        return zip_path(env_path)
 
-    def zip_env(self, env_path):
-        """
-        Zip env directory
 
-        Parameters
-        ----------
-        env_path : string
+def zip_path(path, out_file=None):
+    """
+    Zip up directory
 
-        Returns
-        -------
-        path : string
-            path to zipped file
-        """
+    Parameters
+    ----------
+    path : string
+    out_path : str
+        Output zip-file; if note given, same as input path with
+        .zip appended
 
-        fname = os.path.basename(env_path) + '.zip'
-        env_dir = os.path.dirname(env_path)
-        zFile = os.path.join(env_dir, fname)
-        
-        # ZipFile does not have a contextmanager in Python 2.6
-        f = zipfile.ZipFile(zFile, 'w', allowZip64=True)
-        try:
-            logger.info('Creating: %s' % zFile)
-            for root, dirs, files in os.walk(env_path):
-                for file in files:
-                    relfile = os.path.join(
-                        os.path.relpath(root, env_dir), file)
-                    absfile = os.path.join(root, file)
-                    try:
-                        os.stat(absfile)
-                    except OSError:
-                        logger.info('Skipping zip for %s' % absfile)
-                        continue
-                    f.write(absfile, relfile)
-            return zFile
-        finally:
-            f.close()
+    Returns
+    -------
+    path : string
+        path to zipped file
+    """
+
+    fname = os.path.basename(path) + '.zip'
+    env_dir = os.path.dirname(path)
+    zFile = out_file or os.path.join(env_dir, fname)
+
+    # ZipFile does not have a contextmanager in Python 2.6
+    f = zipfile.ZipFile(zFile, 'w', allowZip64=True)
+    try:
+        logger.info('Creating: %s' % zFile)
+        for root, dirs, files in os.walk(path):
+            for file in files:
+                relfile = os.path.join(
+                    os.path.relpath(root, env_dir), file)
+                absfile = os.path.join(root, file)
+                try:
+                    os.stat(absfile)
+                except OSError:
+                    logger.info('Skipping zip for %s' % absfile)
+                    continue
+                f.write(absfile, relfile)
+        return zFile
+    finally:
+        f.close()

--- a/knit/tests/test_core.py
+++ b/knit/tests/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import time
 import pytest
@@ -156,9 +158,11 @@ def test_memory(k):
 
 def test_cmd_w_conda_env(k):
     env_zip = k.create_env(env_name='dev', packages=['python=2.7'], remove=True)
-    cmd = "$PYTHON_BIN -c 'import sys; print(sys.version_info);" \
-          " import random; print(str(random.random()))'"
-    k.start(cmd, env=env_zip, memory=128)
+    bn = os.path.basename(env_zip)
+    pref = bn + '/' + bn[:-4]
+    cmd = ("{pref}/bin/python -c 'import sys; print(sys.version_info);"
+           " import random; print(str(random.random()))'".format(pref=pref))
+    k.start(cmd, files=[env_zip], memory=128)
 
     if not k.wait_for_completion(30):
         k.kill()

--- a/knit/tests/test_core.py
+++ b/knit/tests/test_core.py
@@ -3,7 +3,7 @@ import time
 import pytest
 import socket
 
-from knit import Knit
+from knit import Knit, zip_path
 from knit.exceptions import YARNException, KnitException
 
 
@@ -16,13 +16,15 @@ inside_docker = check_docker
 
 def wait_for_status(k, status, timeout=30):
     cur_status = k.runtime_status()
+    print("Current status is {0}, waiting for {1}".format(cur_status, status),
+          end='')
     while cur_status != status and timeout > 0:
-        print("Current status is {0}, waiting for {1}".format(cur_status, status))
-
+        print('.', end='')
         time.sleep(2)
         timeout -= 2
         cur_status = k.runtime_status()
 
+    print()
     time.sleep(1)
     return timeout > 0
 
@@ -236,11 +238,42 @@ def test_yarn_kill_status(k):
     assert status in ['KILLED', 'NONE']
 
 
+def test_env_pass(k):
+    cmd = "env"
+    k.start(cmd, envvars={'other': 'blah'}, num_containers=1)
+
+    wait_for_status(k, 'FINISHED')
+    time.sleep(2)
+    out = k.logs()
+    assert "other=blah" in str(out)
+
+
+def test_files(k):
+    cmd = 'ls'
+    k.start(cmd, files=[__file__])
+    wait_for_status(k, 'FINISHED')
+    time.sleep(2)
+    out = k.logs()
+    assert os.path.basename(__file__) in str(out)
+
+
+def test_files_zip(k):
+    import tempfile
+    d = tempfile.mkdtemp()
+    os.makedirs(d + '/temp')
+    open(d + '/temp/afile', 'w').write('Hello')
+    zip_path(d + '/temp')
+    k.start('ls temp.zip/temp', files=[d + '/temp.zip'])
+    wait_for_status(k, 'FINISHED')
+    time.sleep(2)
+    out = k.logs()
+    assert 'afile' in str(out)
+
+
 def test_lang(k):
     cmd = "env"
     orig_lang = k.lang
-    k.lang = 'en_US.utf-8'
-    k.start(cmd, num_containers=1)
+    k.start(cmd, envvars={'KNIT_LANG': 'en_US.utf-8'}, num_containers=1)
 
     wait_for_status(k, 'FINISHED')
     time.sleep(2)

--- a/knit/utils.py
+++ b/knit/utils.py
@@ -41,4 +41,5 @@ def get_log_content(s):
     st = """<td class="content">"""
     ind0 = s.find(st) + len(st)
     ind1 = s[ind0:].find("</td>")
-    return s[ind0:ind0+ind1]
+    out = s[ind0:ind0+ind1]
+    return out.lstrip('\n          <pre>').rstrip('</pre>\n        ')

--- a/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
@@ -25,7 +25,7 @@ import io.continuum.knit.Utils._
 import py4j.GatewayServer
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.{ArrayBuffer, HashMap}
+import scala.collection.mutable.{ArrayBuffer, HashMap, Map}
 
 object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler with NMClientAsync.CallbackHandler {
   
@@ -40,8 +40,8 @@ object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler wi
   var outstandingRequests = List[ContainerRequest]()
   var cred: Credentials = _
   
-  var files: String = _
-  var pythonEnv: String = _
+  var files: ArrayBuffer[String] = _
+  var envin: Map[String, String] = _
   var shellCMD: String = _
   
   var numRequested = 0
@@ -94,11 +94,21 @@ object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler wi
     nmClient.start()
   }
   
-  def init(pythonEnv: String, files: String, shellCMD: String, numContainers: Int, vCores: Int, mem: Int) {
-    logger.info("Init application master")
-    
-    this.pythonEnv = pythonEnv
-    this.files = files
+  def init(files: java.util.ArrayList[String], envin: java.util.HashMap[String, String],
+           shellCMD: String, numContainers: Int, vCores: Int, mem: Int) {
+    logger.info("Init application master with files and env:")
+    logger.info(f"$files")
+    logger.info(f"$envin")
+    this.files = ArrayBuffer[String]()
+    this.envin = Map[String, String]()
+
+    for ((k, v) <- envin.asScala) {
+      this.envin(k) = v
+    }
+    for (k <- files.asScala) {
+      this.files += k
+    }
+
     this.shellCMD = shellCMD
     
     val previousAttempts = registerResponse.getContainersFromPreviousAttempts
@@ -145,7 +155,7 @@ object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler wi
     val lang = sys.env.get("KNIT_LANG").get
     val stagingDirPath = new Path(System.getenv("KNIT_YARN_STAGING_DIR"))
 
-    logger.debug(s"User: $user StagingDir: $stagingDirPath")
+    logger.info(s"User: $user StagingDir: $stagingDirPath")
     logger.info(s"Running command in container: $shellCMD")
 
     //containers allocated, first remove all requests    
@@ -162,35 +172,26 @@ object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler wi
 
         val localResources = HashMap[String, LocalResource]()
         val env = collection.mutable.Map[String, String]()
+        for ((k, v) <- this.envin) {
+          env(k) = v
+        }
   
-        //setup local resources
         if (files.length > 0) {
-          val fileArray = files.split(",")
-          for (fileName <- fileArray) {
-            val file = new File(fileName)
-            val name = file.getName
-    
-            logger.debug(s"Pulling File: $name")
-            val localfile = Records.newRecord(classOf[LocalResource])
-            val HDFS_FILE_PATH = new Path(stagingDirPath, name).makeQualified(fs.getUri, fs.getWorkingDirectory)
-            setUpLocalResource(HDFS_FILE_PATH, localfile)
-            localResources(name) = localfile
+          for (fileName <- files) {
+            var iszip = false
+            if (fileName.endsWith(".zip")) {
+              iszip = true
+            }
+            val fileUpload = Records.newRecord(classOf[LocalResource])
+            var p = new Path(fileName)
+            val name = p.getName  
+            val p2 = new Path(".knitDeps/" + name)
+            logger.info(f"RESOURCE: $p => $p2 $name $iszip")
+            setUpLocalResource(p2, fileUpload, archived=iszip)
+            localResources(name) = fileUpload
           }
         }
-  
-        //setup python resources
-        if (pythonEnv.nonEmpty) {
-          val appMasterPython = Records.newRecord(classOf[LocalResource])
-          val envFile = new File(pythonEnv)
-          val envZip = envFile.getName
-          val envName = envZip.split('.').init(0)
-          val PYTHON_ZIP = new Path(stagingDirPath, envZip).makeQualified(fs.getUri, fs.getWorkingDirectory)
-          setUpLocalResource(PYTHON_ZIP, appMasterPython, archived = true)
-          // set up local ENV
-          env("PYTHON_BIN") = s"./PYTHON_DIR/$envName/bin/python"
-          env("CONDA_PREFIX") = s"./PYTHON_DIR/$envName/"
-          localResources("PYTHON_DIR") = appMasterPython
-        }
+
         val l = s"$lang"
         logger.info(s"Setting container language to '$lang'")
         env("LC_ALL") = l

--- a/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
@@ -172,6 +172,14 @@ object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler wi
 
         val localResources = HashMap[String, LocalResource]()
         val env = collection.mutable.Map[String, String]()
+        
+        // KNIT_LANG env from Knit.lang
+        val l = s"$lang"
+        logger.info(s"Setting container language to '$lang'")
+        env("LC_ALL") = l
+        env("LANG") = l
+
+        // All other variables; these take prescedence if also include language things
         for ((k, v) <- this.envin) {
           env(k) = v
         }
@@ -186,16 +194,12 @@ object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler wi
             var p = new Path(fileName)
             val name = p.getName  
             val p2 = new Path(".knitDeps/" + name)
-            logger.info(f"RESOURCE: $p => $p2 $name $iszip")
+            logger.info(f"RESOURCE: $p => $p2 archive=$iszip")
             setUpLocalResource(p2, fileUpload, archived=iszip)
             localResources(name) = fileUpload
           }
         }
 
-        val l = s"$lang"
-        logger.info(s"Setting container language to '$lang'")
-        env("LC_ALL") = l
-        env("LANG") = l
         setUpEnv(env)
         
         val ctx = Records.newRecord(classOf[ContainerLaunchContext])


### PR DESCRIPTION
- files is a list for uploading, and should include any zipped python env. Things
ending in .zip will be treated as archives with a name like the filename minus the
.zip. Existing resources in hdfs can also be passed (no upload).
- environment (set of key/values) is passed as a dictionary.
- for now, dask launch command is simply derived from the environment passed, as
before.

Meantime:
changed application and client kill to atexit.  