### PR TITLE
handled the application master clean up in case of success

### DIFF
--- a/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
+++ b/knit_jvm/src/main/scala/io/continuum/knit/ApplicationMaster.scala
@@ -243,24 +243,19 @@ object ApplicationMaster extends Logging with AMRMClientAsync.CallbackHandler wi
     }
 
     if (numCompleted >= numRequested) {
-      nmClient.stop()
-      
       try {
         if (numFailed > 0) {
+          // Unregister application master only when it is failed
           rmClient.unregisterApplicationMaster(FinalApplicationStatus.FAILED, "", "")
-        } else {
-          rmClient.unregisterApplicationMaster(FinalApplicationStatus.SUCCEEDED, "", "")
+          nmClient.stop()
+          rmClient.stop()
+          gatewayServer.shutdown()
+          done = true
         }
       } catch {
         case e: Exception => 
           logger.error("Exception", e)
       }
-      
-      rmClient.stop()
-      
-      gatewayServer.shutdown()
-      
-      done = true
     }
   }
   


### PR DESCRIPTION
When we run the dask yarn cluster with auto scaling i.e., using Adaptive class , it automatically triggers the scaling down and up of cluster.But the problem is when all the workers have been removed the master application is also getting killed.So when again scale up function has been called , the addition of the containers is not happening.

The application master removal has been handled in this PR, where removal is done only when it is failed but not on success

